### PR TITLE
YUV->RGBA conversion: Special case the edge pixels, do the middle without index clamping

### DIFF
--- a/codecs/yuv/src/bt601.rs
+++ b/codecs/yuv/src/bt601.rs
@@ -1,19 +1,7 @@
 //! YUV-to-RGB decode
 
 fn clamp(v: f32) -> u8 {
-    if v.is_nan() {
-        return 0;
-    }
-
-    if v < 0.0 {
-        return 0;
-    }
-
-    if v > 255.0 {
-        return 255;
-    }
-
-    (v + 0.5) as u8
+    (v + 0.5).max(0.0).min(255.0) as u8
 }
 
 pub fn clamped_index(width: i32, height: i32, x: i32, y: i32) -> usize {

--- a/codecs/yuv/src/bt601.rs
+++ b/codecs/yuv/src/bt601.rs
@@ -8,42 +8,64 @@ pub fn clamped_index(width: i32, height: i32, x: i32, y: i32) -> usize {
     (x.max(0).min(width - 1) + (y.max(0).min(height - 1) * width)) as usize
 }
 
+pub fn unclamped_index(width: i32, x: i32, y: i32) -> usize {
+    (x + y * width) as usize
+}
+
 pub fn sample_chroma_for_luma(
     chroma: &[u8],
     chroma_width: usize,
+    chroma_height: usize,
     luma_x: usize,
     luma_y: usize,
+    clamp: bool,
 ) -> u8 {
     let width = chroma_width as i32;
-    let height = chroma.len() as i32 / width;
+    let height = chroma_height as i32;
 
-    let chroma_x = if luma_x == 0 {
-        -1
-    } else {
-        (luma_x as i32 - 1) / 2
-    };
-    let chroma_y = if luma_y == 0 {
-        -1
-    } else {
-        (luma_y as i32 - 1) / 2
-    };
+    let sample_00;
+    let sample_01;
+    let sample_10;
+    let sample_11;
 
-    let sample_00 = chroma
-        .get(clamped_index(width, height, chroma_x, chroma_y))
-        .copied()
-        .unwrap_or(0) as u16;
-    let sample_10 = chroma
-        .get(clamped_index(width, height, chroma_x + 1, chroma_y))
-        .copied()
-        .unwrap_or(0) as u16;
-    let sample_01 = chroma
-        .get(clamped_index(width, height, chroma_x, chroma_y + 1))
-        .copied()
-        .unwrap_or(0) as u16;
-    let sample_11 = chroma
-        .get(clamped_index(width, height, chroma_x + 1, chroma_y + 1))
-        .copied()
-        .unwrap_or(0) as u16;
+    if clamp {
+        let chroma_x = if luma_x == 0 {
+            -1
+        } else {
+            (luma_x as i32 - 1) / 2
+        };
+        let chroma_y = if luma_y == 0 {
+            -1
+        } else {
+            (luma_y as i32 - 1) / 2
+        };
+
+        sample_00 = chroma
+            .get(clamped_index(width, height, chroma_x, chroma_y))
+            .copied()
+            .unwrap_or(0) as u16;
+        sample_10 = chroma
+            .get(clamped_index(width, height, chroma_x + 1, chroma_y))
+            .copied()
+            .unwrap_or(0) as u16;
+        sample_01 = chroma
+            .get(clamped_index(width, height, chroma_x, chroma_y + 1))
+            .copied()
+            .unwrap_or(0) as u16;
+        sample_11 = chroma
+            .get(clamped_index(width, height, chroma_x + 1, chroma_y + 1))
+            .copied()
+            .unwrap_or(0) as u16;
+    } else {
+        let chroma_x = (luma_x as i32 - 1) / 2;
+        let chroma_y = (luma_y as i32 - 1) / 2;
+
+        let base = unclamped_index(width, chroma_x, chroma_y);
+        sample_00 = chroma.get(base).copied().unwrap_or(0) as u16;
+        sample_10 = chroma.get(base + 1).copied().unwrap_or(0) as u16;
+        sample_01 = chroma.get(base + chroma_width).copied().unwrap_or(0) as u16;
+        sample_11 = chroma.get(base + chroma_width + 1).copied().unwrap_or(0) as u16;
+    }
 
     let interp_left = luma_x % 2 != 0;
     let interp_top = luma_y % 2 != 0;
@@ -107,15 +129,19 @@ pub fn yuv420_to_rgba(
     br_width: usize,
 ) -> Vec<u8> {
     let y_height = y.len() / y_width;
+    let br_height = chroma_b.len() / br_width;
 
     let mut rgba = Vec::new();
     rgba.resize(y.len() * 4, 0);
 
-    for y_pos in 0..y_height {
-        for x_pos in 0..y_width {
+    // do the bulk of the pixels faster, with no clamping, leaving out the edges
+    for y_pos in 1..y_height - 1 {
+        for x_pos in 1..y_width - 1 {
             let y_sample = y.get(x_pos + y_pos * y_width).copied().unwrap_or(0) as f32;
-            let b_sample = sample_chroma_for_luma(chroma_b, br_width, x_pos, y_pos) as f32;
-            let r_sample = sample_chroma_for_luma(chroma_r, br_width, x_pos, y_pos) as f32;
+            let b_sample =
+                sample_chroma_for_luma(chroma_b, br_width, br_height, x_pos, y_pos, false) as f32;
+            let r_sample =
+                sample_chroma_for_luma(chroma_r, br_width, br_height, x_pos, y_pos, false) as f32;
 
             convert_and_write_pixel(
                 (y_sample, b_sample, r_sample),
@@ -123,6 +149,44 @@ pub fn yuv420_to_rgba(
                 y_width,
                 x_pos,
                 y_pos,
+            );
+        }
+    }
+
+    // doing the sides with clamping
+    for y_pos in 0..y_height {
+        for x_pos in [0, y_width - 1].iter() {
+            let y_sample = y.get(x_pos + y_pos * y_width).copied().unwrap_or(0) as f32;
+            let b_sample =
+                sample_chroma_for_luma(chroma_b, br_width, br_height, *x_pos, y_pos, true) as f32;
+            let r_sample =
+                sample_chroma_for_luma(chroma_r, br_width, br_height, *x_pos, y_pos, true) as f32;
+
+            convert_and_write_pixel(
+                (y_sample, b_sample, r_sample),
+                &mut rgba,
+                y_width,
+                *x_pos,
+                y_pos,
+            );
+        }
+    }
+
+    // doing the top and bottom edges with clamping
+    for x_pos in 0..y_width {
+        for y_pos in [0, y_height - 1].iter() {
+            let y_sample = y.get(x_pos + y_pos * y_width).copied().unwrap_or(0) as f32;
+            let b_sample =
+                sample_chroma_for_luma(chroma_b, br_width, br_height, x_pos, *y_pos, true) as f32;
+            let r_sample =
+                sample_chroma_for_luma(chroma_r, br_width, br_height, x_pos, *y_pos, true) as f32;
+
+            convert_and_write_pixel(
+                (y_sample, b_sample, r_sample),
+                &mut rgba,
+                y_width,
+                x_pos,
+                *y_pos,
             );
         }
     }


### PR DESCRIPTION
This PR splits the color space conversion of the edge pixels and "the rest", to allow fewer operations on the inside pixels that are the straightforward case.

The effects of each included commit (plus two excluded ones) on the runtime of a particular command are:

![image](https://user-images.githubusercontent.com/288816/105242627-7c9b1300-5b6e-11eb-9116-bbf6abf577a9.png)

These numbers are the output of `time` (in seconds) running the following command (after compilation is done), with each sample averaged from three runs. The error bars are one standard deviation long in both directions.

`time cargo run --package=exporter --release --  ../../Downloads/z0r-de_4145.swf --frames 1000`

I also commented out the actual saving of the frames into files, so the effect on rendering itself is more directly measurable.

While the "utility functions" commit regresses a little bit, doing it is almost a necessity for the one after it, which is the one providing the significant gains.

Overall, these changes sped up the rendering by about 25%.

I also made two more experiments (independently) that I then discarded because they both regressed slightly:
The first one was doing the bilinear interpolation differently: on `f32` numbers, in two steps (the usual way, in a rotated H-shape).
The second one was simply omitting the `.min()` and `.max()` calls from `clamp()`, relying on the saturating property of the `f32` to `u8` cast instead.

I don't know if this is starting to stretch the "code simplicity/cleanliness" vs. "runtime performance" trade-off a little bit too far, but at least there is still no `unsafe` anywhere... :)