### PR TITLE
When seeking, take the modulo of the frame id with the number of frames

### DIFF
--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -149,7 +149,7 @@ impl<'gc> Video<'gc> {
     }
 
     /// Seek to a particular frame in the video stream.
-    pub fn seek(self, context: &mut UpdateContext<'_, 'gc, '_>, frame_id: u32) {
+    pub fn seek(self, context: &mut UpdateContext<'_, 'gc, '_>, mut frame_id: u32) {
         let read = self.0.read();
         if let VideoStream::Uninstantiated(_) = &read.stream {
             drop(read);
@@ -159,6 +159,11 @@ impl<'gc> Video<'gc> {
 
             return;
         };
+
+        {
+            let VideoSource::SWF { movie: _, streamdef, frames: _ } = &*read.source.read();
+            frame_id = frame_id % streamdef.num_frames as u32;
+        }
 
         let last_frame = read.decoded_frame.as_ref().map(|(lf, _)| *lf);
 


### PR DESCRIPTION
This is based on (and includes): https://github.com/kmeisthax/ruffle/pull/14

I'm not entirely sure exactly how and where this should be done, which is why I marked it as draft, but the effect it has looks like it helps; particularly with at least: https://z0r.de/L/z0r-de_1843.swf
This loop has a video in it with only 8 frames, but seeks it repeatedly all the way up to around frame 15 or so.

I can record videos about this too if you want me to.