### PR TITLE
Optimize the "gather" phase of decoding a h263 block

### DIFF
--- a/codecs/h263/src/decoder/cpu/gather.rs
+++ b/codecs/h263/src/decoder/cpu/gather.rs
@@ -16,23 +16,11 @@ use crate::types::{MacroblockType, MotionVector};
 fn read_sample(pixel_array: &[u8], samples_per_row: usize, pos: (isize, isize)) -> u8 {
     let (x, y) = pos;
 
-    let x = if x < 0 {
-        0
-    } else if x >= samples_per_row as isize {
-        samples_per_row.saturating_sub(1)
-    } else {
-        x as usize
-    };
+    let x = x.clamp(0, samples_per_row.saturating_sub(1) as isize) as usize;
 
     let height = pixel_array.len() / samples_per_row;
 
-    let y = if y < 0 {
-        0
-    } else if y >= height as isize {
-        height.saturating_sub(1)
-    } else {
-        y as usize
-    };
+    let y = y.clamp(0, height.saturating_sub(1) as isize) as usize;
 
     pixel_array
         .get(x + (y * samples_per_row))

--- a/codecs/h263/src/decoder/cpu/gather.rs
+++ b/codecs/h263/src/decoder/cpu/gather.rs
@@ -70,36 +70,39 @@ fn gather_block(
     let block_cols = (samples_per_row as isize - pos.0 as isize).clamp(0, 8);
     let block_rows = (array_height as isize - pos.1 as isize).clamp(0, 8);
 
-    for (j, v) in (y..y + block_rows).enumerate() {
-        for (i, u) in (x..x + block_cols).enumerate() {
-            let sample_0_0 = read_sample(pixel_array, samples_per_row, (u, v));
-
-            if !x_interp && !y_interp {
-                target[pos.0 + i + ((pos.1 + j) * samples_per_row)] = sample_0_0;
-                continue;
-            }
-
-            let sample_1_0 = read_sample(pixel_array, samples_per_row, (u + 1, v));
-            let sample_0_1 = read_sample(pixel_array, samples_per_row, (u, v + 1));
-            let sample_1_1 = read_sample(pixel_array, samples_per_row, (u + 1, v + 1));
-
-            if x_interp && y_interp {
-                // special case to only round once
-
-                let sample = ((sample_0_0 as u16
-                    + sample_1_0 as u16
-                    + sample_0_1 as u16
-                    + sample_1_1 as u16
-                    + 2) // for proper rounding
-                    / 4) as u8;
-
-                target[pos.0 + i + ((pos.1 + j) * samples_per_row)] = sample;
-            } else {
-                let sample_mid_0 = lerp(sample_0_0, sample_1_0, x_interp);
-                let sample_mid_1 = lerp(sample_0_1, sample_1_1, x_interp);
-
+    if !x_interp && !y_interp {
+        for (j, v) in (y..y + block_rows).enumerate() {
+            for (i, u) in (x..x + block_cols).enumerate() {
                 target[pos.0 + i + ((pos.1 + j) * samples_per_row)] =
-                    lerp(sample_mid_0, sample_mid_1, y_interp);
+                    read_sample(pixel_array, samples_per_row, (u, v));
+            }
+        }
+    } else {
+        for (j, v) in (y..y + block_rows).enumerate() {
+            for (i, u) in (x..x + block_cols).enumerate() {
+                let sample_0_0 = read_sample(pixel_array, samples_per_row, (u, v));
+                let sample_1_0 = read_sample(pixel_array, samples_per_row, (u + 1, v));
+                let sample_0_1 = read_sample(pixel_array, samples_per_row, (u, v + 1));
+                let sample_1_1 = read_sample(pixel_array, samples_per_row, (u + 1, v + 1));
+
+                if x_interp && y_interp {
+                    // special case to only round once
+
+                    let sample = ((sample_0_0 as u16
+                        + sample_1_0 as u16
+                        + sample_0_1 as u16
+                        + sample_1_1 as u16
+                        + 2) // for proper rounding
+                        / 4) as u8;
+
+                    target[pos.0 + i + ((pos.1 + j) * samples_per_row)] = sample;
+                } else {
+                    let sample_mid_0 = lerp(sample_0_0, sample_1_0, x_interp);
+                    let sample_mid_1 = lerp(sample_0_1, sample_1_1, x_interp);
+
+                    target[pos.0 + i + ((pos.1 + j) * samples_per_row)] =
+                        lerp(sample_mid_0, sample_mid_1, y_interp);
+                }
             }
         }
     }

--- a/codecs/h263/src/decoder/cpu/gather.rs
+++ b/codecs/h263/src/decoder/cpu/gather.rs
@@ -67,16 +67,11 @@ fn gather_block(
     let y = pos.1 as isize + y_delta as isize;
     let array_height = pixel_array.len() / samples_per_row;
 
-    for (i, u) in (x..x + 8).enumerate() {
-        if (pos.0 + i) >= samples_per_row {
-            continue;
-        }
+    let block_cols = (samples_per_row as isize - pos.0 as isize).clamp(0, 8);
+    let block_rows = (array_height as isize - pos.1 as isize).clamp(0, 8);
 
-        for (j, v) in (y..y + 8).enumerate() {
-            if (pos.1 + j) >= array_height {
-                continue;
-            }
-
+    for (i, u) in (x..x + block_cols).enumerate() {
+        for (j, v) in (y..y + block_rows).enumerate() {
             let sample_0_0 = read_sample(pixel_array, samples_per_row, (u, v));
 
             if !x_interp && !y_interp {

--- a/codecs/h263/src/decoder/cpu/gather.rs
+++ b/codecs/h263/src/decoder/cpu/gather.rs
@@ -78,6 +78,12 @@ fn gather_block(
             }
 
             let sample_0_0 = read_sample(pixel_array, samples_per_row, (u, v));
+
+            if !x_interp && !y_interp {
+                target[pos.0 + i + ((pos.1 + j) * samples_per_row)] = sample_0_0;
+                continue;
+            }
+
             let sample_1_0 = read_sample(pixel_array, samples_per_row, (u + 1, v));
             let sample_0_1 = read_sample(pixel_array, samples_per_row, (u, v + 1));
             let sample_1_1 = read_sample(pixel_array, samples_per_row, (u + 1, v + 1));

--- a/codecs/h263/src/decoder/cpu/gather.rs
+++ b/codecs/h263/src/decoder/cpu/gather.rs
@@ -70,8 +70,8 @@ fn gather_block(
     let block_cols = (samples_per_row as isize - pos.0 as isize).clamp(0, 8);
     let block_rows = (array_height as isize - pos.1 as isize).clamp(0, 8);
 
-    for (i, u) in (x..x + block_cols).enumerate() {
-        for (j, v) in (y..y + block_rows).enumerate() {
+    for (j, v) in (y..y + block_rows).enumerate() {
+        for (i, u) in (x..x + block_cols).enumerate() {
             let sample_0_0 = read_sample(pixel_array, samples_per_row, (u, v));
 
             if !x_interp && !y_interp {


### PR DESCRIPTION
According to the Developer Tools of my browser, a significant amount of time is spent in the "gather" phase of decoding blocks.

These changes bring an *overall* ~8.5% speedup (at least on desktop) by optimizing just this phase, as measured by running a random selection[1] of z0r.de loops through the `timedemo` application.

My results on measuring the cumulative speedup brought by each commit are:
![image](https://user-images.githubusercontent.com/288816/128100902-e523f3db-1094-46f5-aff8-c38555fb41b8.png)
Keep in mind that I recorded these quite a while ago, so the relative timings might have changed since then.
Each measurement was done 3 times, then averaged, to make it at least look like it makes any sense.

The last commit on the chart, "unsafe sample" is not in this PR, because... well, because it's `unsafe`. I think it could still make sense to do something similar in the future (eliminating unnecessary range checks when indexing into a frame), by way of either cleverly phrasing the code (using iterators, or something), or actually using `get_unchecked()`, and adding some `debug_assert!()`s manually, as needed.

Feel free to pick and choose (although the commits are fairly interdependent), and please verify that actual functionality is not altered in any way by these changes.

[1]: I actually picked loops containing fairly high resolution videos that performed really badly compared to the rest, on my machine, in Firefox.

----

Another significant factor for runtime is the colorspace conversion. That could use a little work as well. I'm still not convinced that the "correct" (at least by intention...) interpolation I added was worth the runtime cost in image quality.

And finally, when the `bulk-memory` extension can be finally enabled on web, it will make a huge difference, essentially for free.